### PR TITLE
Add shortcuts to avoid unnecessary clks

### DIFF
--- a/rowdecode.vhd
+++ b/rowdecode.vhd
@@ -1,21 +1,21 @@
 ----------------------------------------------------------------------------------
--- Company: 
--- Engineer: 
--- 
+-- Company:
+-- Engineer:
+--
 -- Create Date: 09/24/2019 09:43:42 AM
--- Design Name: 
+-- Design Name:
 -- Module Name: rowdecode - Behavioral
--- Project Name: 
--- Target Devices: 
--- Tool Versions: 
--- Description: 
--- 
--- Dependencies: 
--- 
+-- Project Name:
+-- Target Devices:
+-- Tool Versions:
+-- Description:
+--
+-- Dependencies:
+--
 -- Revision:
 -- Revision 0.01 - File Created
 -- Additional Comments:
--- 
+--
 ----------------------------------------------------------------------------------
 
 
@@ -33,7 +33,7 @@ use ieee.std_logic_unsigned.all;
 entity rowdecode is port(
     row: in std_logic_vector(13 downto 0);
     clk: in std_logic;
-    
+
     rdy: out std_logic;
     nhits: out std_logic_vector(2 downto 0);
     nbits: out std_logic_vector(3 downto 0);
@@ -103,14 +103,20 @@ begin
                         if (row(pos)='0') then
                             node1 <= "01";
                             pos := pos-1;
-                         elsif (row(pos-1)='1') then
+                        elsif (row(pos-1)='1') then
                             node1<= "11";
                             pos := pos-2;
-                         else
+                        else
                             node1<="10";
                             pos := pos-2;
-                         end if;
-                         state <= tier1;
+                        end if;
+
+                        -- Shortcut to tier 2
+                        if(node0(0)='1') then
+                            state <= tier1;
+                        else
+                            state <= tier2;
+                        end if;
                     elsif (node0(0)='1') and (node2="00") then
                      -- Fill node 2
                         if (row(pos)='0') then
@@ -143,7 +149,13 @@ begin
                             node3<="10";
                             pos := pos-2;
                          end if;
-                         state <= tier2;
+
+                        -- Shortcut to end
+                        if(node1(0)='0') and (node2="00") then
+                            state <= combine;
+                        else
+                            state <= tier2;
+                        end if;
                     elsif (node1(0)='1') and (node4="00") then
                      -- Fill node 4
                         if (row(pos)='0') then
@@ -156,7 +168,13 @@ begin
                             node4<="10";
                             pos := pos-2;
                          end if;
-                         state <= tier2;
+
+                         -- Shortcut to end
+                         if(node2="00") then
+                             state <= combine;
+                         else
+                             state <= tier2;
+                         end if;
                      elsif (node2(1)='1') and (node5="00") then
                         -- Fill node 5
                         if (row(pos)='0') then
@@ -170,6 +188,12 @@ begin
                             pos := pos-2;
                          end if;
                          state <= tier2;
+                         -- Shortcut to end
+                         if(node2(0)='0') then
+                            state <= combine;
+                        else
+                            state <= tier2;
+                        end if;
                      elsif (node2(0)='1') and (node6="00") then
                         -- Fill node 6
                         if (row(pos)='0') then
@@ -210,7 +234,7 @@ begin
                     end loop;
                     nhits <= std_logic_vector(to_unsigned(nhits_tmp, nhits'length));
 
-                    -- The length of the encoded row in bits is given by the 
+                    -- The length of the encoded row in bits is given by the
                     -- value of the 'pos' variable.
                     nbits <= std_logic_vector(to_unsigned(13-pos, nbits'length));
 

--- a/test.tcl
+++ b/test.tcl
@@ -1788,3 +1788,4 @@ puts $fp "[get_value -radix bin row] [get_value -radix bin rdy] [get_value -radi
 restart
 
 close $fp
+exit

--- a/write_test_tcl.py
+++ b/write_test_tcl.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from textwrap import dedent
 from encoder import Enc8
 
@@ -23,7 +25,7 @@ for k, v in Enc8.items():
         restart
         ''')
 
-text = text + '\nclose $fp'
+text = text + '\nclose $fp' + '\nexit'
 
 
 with open('test.tcl','w') as f:


### PR DESCRIPTION
In the previous implementation, we would sometimes spend unnecessary time in each tier if only the left half of the tier is filled. E.g. with this tree representation:

```
   0
  1 2
3 4 5 6
```

we would always remain in state `tier1` after node 0 is filled. If node 2 was not present, we would then wait one clock cycle, and finally proceed to node 3. This can be avoided by -- while filling node 1 -- checking node 0 to see whether node 2 is present. If node 2 is not present, we can then directly move on to node 3. A similar argument can be applied in tier 3, where we previously linearly transitioned through the nodes from left to right, although it is possible to skip ahead from e.g. node 3 to the end if nodes 4-6 are not present.

This PR implements these shortcuts to the next tier / the end.